### PR TITLE
Fix liability percentage parsing

### DIFF
--- a/src/valuation/evaluateCase.ts
+++ b/src/valuation/evaluateCase.ts
@@ -48,7 +48,8 @@ export async function evaluateCase(newCase: any): Promise<EvaluationResult> {
     console.log('💰 Predicted evaluator amount:', evaluatorAmount);
     
     // Step 5: Calculate mediator proposal
-    const policyLimits = newCase.policy_limits_num || parseInt(String(newCase.PolicyLimits || '0').replace(/[$,]/g, '')) || 0;
+    const policyLimitStr = newCase.policyLimits ?? newCase.PolicyLimits ?? '0';
+    const policyLimits = newCase.policy_limits_num || parseInt(String(policyLimitStr).replace(/[$,]/g, '')) || 0;
     let mediatorAmount: number;
     
     if (policyLimits > 0 && evaluatorAmount >= (policyLimits * 0.9)) {

--- a/src/valuation/getComparables.ts
+++ b/src/valuation/getComparables.ts
@@ -82,7 +82,12 @@ function calculateSimilarityScore(caseRow: ComparableCase, newCase: NewCase): nu
   
   // Liability percentage proximity (4 points max) - use structured data
   const case_liab = caseRow.liab_pct ? parseFloat(caseRow.liab_pct) : 100;
-  const new_liab = newCase.liab_pct_num || (newCase.LiabPct ? parseFloat(newCase.LiabPct) : 100);
+  const new_liab =
+    typeof newCase.liab_pct_num === 'number'
+      ? newCase.liab_pct_num
+      : newCase.LiabPct
+        ? parseFloat(String(newCase.LiabPct).replace(/[^0-9.]/g, '')) || 100
+        : 100;
   if (case_liab && new_liab) {
     const liab_diff = Math.abs(case_liab - new_liab);
     score += Math.max(0, 4 - (liab_diff / 25));

--- a/src/valuation/getEmbeddings.ts
+++ b/src/valuation/getEmbeddings.ts
@@ -47,7 +47,7 @@ export function serializeCaseForEmbedding(caseData: any): string {
     caseData.injuries || caseData.Injuries || '',
     caseData.surgery || caseData.Surgery || '',
     caseData.inject || caseData.Inject || '',
-    caseData.pol_lim || caseData.PolicyLimits || '',
+    caseData.pol_lim || caseData.policyLimits || caseData.PolicyLimits || '',
     caseData.liab_pct || caseData.LiabPct || '',
     caseData.narrative || caseData.Narrative || '',
     caseData.venue || caseData.Venue || '',

--- a/supabase/functions/find-similar-cases/index.ts
+++ b/supabase/functions/find-similar-cases/index.ts
@@ -30,7 +30,8 @@ const handler = async (req: Request): Promise<Response> => {
     
     // Get parameters for hybrid search
     const liabPct = parseFloat(newCase.LiabPct || '100') || 100;
-    const policyLimits = parseInt(String(newCase.PolicyLimits || '0').replace(/[$,]/g, '')) || 0;
+    const policyLimitStr = newCase.policyLimits ?? newCase.PolicyLimits ?? '0';
+    const policyLimits = newCase.policy_limits_num || parseInt(String(policyLimitStr).replace(/[$,]/g, '')) || 0;
     const policyBucket = policyLimits > 500000 ? 'high' : policyLimits > 100000 ? 'mid' : 'low';
     const tbiLevel = newCase.tbiLevel || 0;
     const hasSurgery = !!(newCase.Surgery && newCase.Surgery !== 'None');


### PR DESCRIPTION
## Summary
- correctly parse `liab_pct_num` before falling back to `LiabPct`

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: 49 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687420e69614832a8f31bbfd3a0dd18f