### PR TITLE
Add case data refresh instructions and env key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,14 @@ The application now includes an advanced AI-first case evaluation system with:
 - **Transparent Deductions**: Shows exactly what factors reduced the evaluation and by how much
 
 To adjust deduction percentages or add new risk factors, edit the deduction engine in `src/valuation/deductionEngine.ts`.
+
+### Refreshing Case Data
+
+After importing new cases into the `cases_master` table, run the refresh script to normalize the data and create embeddings:
+
+```bash
+SUPABASE_SERVICE_ROLE_KEY=<service_key> OPENAI_API_KEY=<openai_key> \
+  ts-node scripts/refreshCaseData.ts
+```
+
+This populates missing numeric fields and embeddings so the AI evaluators include your latest cases.

--- a/scripts/refreshCaseData.ts
+++ b/scripts/refreshCaseData.ts
@@ -1,0 +1,61 @@
+import { createClient } from '@supabase/supabase-js';
+import { serializeCaseForEmbedding, getEmbedding } from '../src/valuation/getEmbeddings';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || 'https://hueccsiuyxjqupxkfhkl.supabase.co';
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const OPENAI_KEY = process.env.OPENAI_API_KEY || process.env.VITE_OPENAI_API_KEY;
+
+if (!SUPABASE_SERVICE_KEY) {
+  console.error('SUPABASE_SERVICE_ROLE_KEY env var required');
+  process.exit(1);
+}
+if (!OPENAI_KEY) {
+  console.error('OPENAI_API_KEY or VITE_OPENAI_API_KEY env var required');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+async function refreshCases() {
+  console.log('🔄 Fetching cases without embeddings...');
+  const { data: cases, error } = await supabase
+    .from('cases_master')
+    .select('*')
+    .is('embedding', null);
+
+  if (error) throw error;
+  if (!cases || cases.length === 0) {
+    console.log('✅ No cases need refresh');
+    return;
+  }
+
+  console.log(`Found ${cases.length} cases to update`);
+
+  for (const row of cases) {
+    try {
+      console.log(`Processing case ${row.case_id}...`);
+      // Normalize data via RPC
+      await supabase.rpc('fn_normalize_case', { p_case_id: row.case_id });
+
+      const text = serializeCaseForEmbedding(row);
+      const embedding = await getEmbedding(text);
+
+      await supabase
+        .from('cases_master')
+        .update({ embedding })
+        .eq('case_id', row.case_id);
+
+      console.log(`✓ Case ${row.case_id} updated`);
+    } catch (err) {
+      console.error(`Failed to process case ${row.case_id}:`, err);
+    }
+  }
+}
+
+refreshCases().then(() => {
+  console.log('🎉 Refresh complete');
+  process.exit(0);
+}).catch(err => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/src/valuation/getEmbeddings.ts
+++ b/src/valuation/getEmbeddings.ts
@@ -12,8 +12,11 @@ interface EmbeddingResponse {
  * Get text embedding from OpenAI
  */
 export async function getEmbedding(text: string): Promise<number[]> {
-  const openaiKey = import.meta.env.VITE_OPENAI_API_KEY;
-  
+  const openaiKey =
+    (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_OPENAI_API_KEY) ||
+    process.env.OPENAI_API_KEY ||
+    process.env.VITE_OPENAI_API_KEY;
+
   if (!openaiKey) {
     throw new Error('OpenAI API key not configured');
   }

--- a/supabase/migrations/20250706120000-3cdb8155-318b-4834-b2e1-4a261311f0b8.sql
+++ b/supabase/migrations/20250706120000-3cdb8155-318b-4834-b2e1-4a261311f0b8.sql
@@ -1,0 +1,16 @@
+-- Automatically normalize case data on insert or update
+
+-- Trigger function that calls fn_normalize_case for new or updated rows
+CREATE OR REPLACE FUNCTION trg_normalize_case()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM fn_normalize_case(NEW.case_id);
+  RETURN NEW;
+END
+$$;
+
+-- Create trigger
+DROP TRIGGER IF EXISTS trg_cases_master_normalize ON cases_master;
+CREATE TRIGGER trg_cases_master_normalize
+AFTER INSERT OR UPDATE ON cases_master
+FOR EACH ROW EXECUTE FUNCTION trg_normalize_case();


### PR DESCRIPTION
## Summary
- add refresh script for case data and embeddings
- auto-normalize cases on insert or update
- document how to refresh data
- support reading OpenAI key from environment for scripts

## Testing
- `npm run lint` *(fails: multiple lint errors)*
- `npx ts-node scripts/testOneCase.ts` *(fails: needs ts-node install)*

------
https://chatgpt.com/codex/tasks/task_e_687422844174832aa02af8e1332dc94f