### PR TITLE
Add other case category

### DIFF
--- a/src/components/wizard-steps/CaseTypeStep.tsx
+++ b/src/components/wizard-steps/CaseTypeStep.tsx
@@ -1,8 +1,14 @@
-
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
 import { CaseData } from "@/types/verdict";
+import { caseCategories } from "@/utils/caseCategories";
 
 interface CaseTypeStepProps {
   formData: Partial<CaseData>;
@@ -10,47 +16,39 @@ interface CaseTypeStepProps {
 }
 
 const CaseTypeStep = ({ formData, setFormData }: CaseTypeStepProps) => {
-  const caseTypes = [
-    "Auto Accident",
-    "Dog Bite", 
-    "Slip and Fall",
-    "Trip and Fall",
-    "Homeowner Premises",
-    "Construction Injury",
-    "Wrongful Death",
-    "Assault/Battery",
-    "Other"
-  ];
-
   return (
     <div className="space-y-6">
       <div className="space-y-2">
         <Label htmlFor="caseType">Case Type (Required)</Label>
-        <Select 
-          value={formData.caseType || ''} 
-          onValueChange={(value) => setFormData({...formData, caseType: value})}
+        <Select
+          value={formData.caseType || ""}
+          onValueChange={(value) =>
+            setFormData({ ...formData, caseType: value })
+          }
         >
           <SelectTrigger>
             <SelectValue placeholder="Select case type" />
           </SelectTrigger>
           <SelectContent>
-            {caseTypes.map(type => (
-              <SelectItem key={type} value={type.toLowerCase().replace(/[^a-z0-9]/g, '-')}>
-                {type}
+            {caseCategories.map((cat) => (
+              <SelectItem key={cat.value} value={cat.value}>
+                {cat.label}
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
       </div>
 
-      {formData.caseType === 'other' && (
+      {formData.caseType === "other" && (
         <div className="space-y-2">
           <Label htmlFor="otherCaseType">Please specify case type</Label>
           <Input
             id="otherCaseType"
             type="text"
-            value={formData.otherCaseType || ''}
-            onChange={(e) => setFormData({...formData, otherCaseType: e.target.value})}
+            value={formData.otherCaseType || ""}
+            onChange={(e) =>
+              setFormData({ ...formData, otherCaseType: e.target.value })
+            }
             placeholder="Enter case type"
           />
         </div>

--- a/src/components/wizard-steps/DateOfLossStep.tsx
+++ b/src/components/wizard-steps/DateOfLossStep.tsx
@@ -11,19 +11,22 @@ interface DateOfLossStepProps {
 const DateOfLossStep = ({ formData, setFormData }: DateOfLossStepProps) => {
   // Check statute of limitations for auto accidents
   const checkStatuteOfLimitations = (dateOfLoss: string, caseType: string) => {
-    if (caseType !== "Auto Accident" || !dateOfLoss) return false;
-    
+    if (caseType !== "auto-accident" || !dateOfLoss) return false;
+
     const dolDate = new Date(dateOfLoss);
     const today = new Date();
     const covidTollDays = 178; // CA Emergency Rule: 4 Apr 2020 – 1 Oct 2020
     const twoYearsInMs = 2 * 365 * 24 * 60 * 60 * 1000;
     const covidTollMs = covidTollDays * 24 * 60 * 60 * 1000;
-    
+
     const timeDiff = today.getTime() - dolDate.getTime();
-    return timeDiff > (twoYearsInMs + covidTollMs);
+    return timeDiff > twoYearsInMs + covidTollMs;
   };
 
-  const isSOLExpired = checkStatuteOfLimitations(formData.dateOfLoss || '', formData.caseType || '');
+  const isSOLExpired = checkStatuteOfLimitations(
+    formData.dateOfLoss || "",
+    formData.caseType || "",
+  );
 
   return (
     <div className="space-y-6">
@@ -32,11 +35,13 @@ const DateOfLossStep = ({ formData, setFormData }: DateOfLossStepProps) => {
         <Input
           id="dateOfLoss"
           type="date"
-          value={formData.dateOfLoss || ''}
-          onChange={(e) => setFormData({...formData, dateOfLoss: e.target.value})}
+          value={formData.dateOfLoss || ""}
+          onChange={(e) =>
+            setFormData({ ...formData, dateOfLoss: e.target.value })
+          }
         />
       </div>
-      
+
       {isSOLExpired && (
         <Alert variant="destructive">
           <AlertDescription>

--- a/src/utils/caseCategories.ts
+++ b/src/utils/caseCategories.ts
@@ -1,0 +1,25 @@
+export interface CaseCategory {
+  value: string;
+  label: string;
+  subCategories: string[];
+}
+
+export const caseCategories: CaseCategory[] = [
+  { value: "auto-accident", label: "Auto Accident", subCategories: [] },
+  { value: "dog-bite", label: "Dog Bite", subCategories: [] },
+  { value: "slip-and-fall", label: "Slip and Fall", subCategories: [] },
+  { value: "trip-and-fall", label: "Trip and Fall", subCategories: [] },
+  {
+    value: "homeowner-premises",
+    label: "Homeowner Premises",
+    subCategories: [],
+  },
+  {
+    value: "construction-injury",
+    label: "Construction Injury",
+    subCategories: [],
+  },
+  { value: "wrongful-death", label: "Wrongful Death", subCategories: [] },
+  { value: "assault-battery", label: "Assault/Battery", subCategories: [] },
+  { value: "other", label: "Other", subCategories: [] },
+];


### PR DESCRIPTION
## Summary
- centralize case categories in utils
- import categories in CaseTypeStep
- show extra input for `other` case type
- update statute check to use slug values

## Testing
- `npx prettier -w src/components/wizard-steps/CaseTypeStep.tsx src/components/wizard-steps/DateOfLossStep.tsx src/utils/caseCategories.ts`
- `npm run lint` *(fails: 49 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6874758e5ca8832a863355b215794eb4