### PR TITLE
Add narrative support in case forms

### DIFF
--- a/src/components/CaseInputForm.tsx
+++ b/src/components/CaseInputForm.tsx
@@ -41,7 +41,12 @@ const CaseInputForm = ({ onSubmit, isLoading }: CaseInputFormProps) => {
     injuryTypes: [],
     diagnosticTests: [],
     treatmentGap: false,
+    narrative: undefined,
   });
+
+  const handleNarrativeUpdate = (text: string) => {
+    setFormData({ ...formData, narrative: text });
+  };
 
   const handleComplete = () => {
     console.log("Form completed with data:", formData);

--- a/src/types/verdict.ts
+++ b/src/types/verdict.ts
@@ -62,6 +62,10 @@ export interface CaseData {
   treatmentGaps?: number;
   priorConditions?: string;
   medicalRecordsAnalysis?: string;
+  /**
+   * Narrative text extracted from uploaded documents
+   */
+  narrative?: string;
 }
 
 export interface PolicyInfo {


### PR DESCRIPTION
## Summary
- add `narrative` optional field to `CaseData`
- track narrative text in `CaseInputForm`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: network access blocked while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6874759aad54832a9e23339b30ca13cc