### PR TITLE
Add explicit exit codes for testOneCase

### DIFF
--- a/scripts/testOneCase.ts
+++ b/scripts/testOneCase.ts
@@ -85,4 +85,10 @@ async function testCaseEvaluation() {
 }
 
 // Run the test
-testCaseEvaluation();
+testCaseEvaluation()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch(() => {
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- exit with code `0` when `testCaseEvaluation` completes successfully
- exit with code `1` if `testCaseEvaluation` fails

## Testing
- `npm run lint` *(fails: 49 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68747760f744832aa30dbdd279a5f3de