### PR TITLE
Fix AI evaluator weight import

### DIFF
--- a/src/valuation/calcEvaluatorAI.ts
+++ b/src/valuation/calcEvaluatorAI.ts
@@ -25,6 +25,12 @@ export interface AIEvaluationResult {
   method: 'ai' | 'traditional' | 'hybrid';
 }
 
+interface WeightsData {
+  defaultInjectionValue: number;
+  surgeryWeights: Record<string, number>;
+  tbiWeights: Record<string, number>;
+}
+
 /**
  * Calculate case evaluation using AI-first approach with smart deductions
  */
@@ -137,7 +143,7 @@ export async function calcEvaluatorAI(
 async function applyWeightsBoost(newCase: any, features: CaseFeatures): Promise<number> {
   try {
     // Import weights dynamically
-    const weights = await import('../valuation/weights.json');
+    const weights = (await import('../valuation/weights.json')).default as WeightsData;
     let boost = 0;
     
     // Add injection value


### PR DESCRIPTION
## Summary
- correctly import weights JSON when applying boosts
- type check imported weights

## Testing
- `npm run lint`
- `npx tsx scripts/testAIEvaluator.ts` *(fails: OpenAI API key not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6874c2a0d5dc832a904556324cc5bbac