### PR TITLE
Refine settlement strategy integration

### DIFF
--- a/src/components/CaseInputForm.tsx
+++ b/src/components/CaseInputForm.tsx
@@ -1,6 +1,7 @@
 
 import { useState } from "react";
 import { CaseData } from "@/types/verdict";
+import { UserType } from "@/types/auth";
 import FormWizard from "./FormWizard";
 import PartiesStep from "./wizard-steps/PartiesStep";
 import CaseTypeStep from "./wizard-steps/CaseTypeStep";
@@ -14,13 +15,15 @@ import SpecialsEarningsStep from "./wizard-steps/SpecialsEarningsStep";
 import LegalInsuranceStep from "./wizard-steps/LegalInsuranceStep";
 import FinalReviewStep from "./wizard-steps/FinalReviewStep";
 import DocumentUploadStep from "./wizard-steps/DocumentUploadStep";
+import SettlementStrategyStep from "./wizard-steps/SettlementStrategyStep";
 
 interface CaseInputFormProps {
   onSubmit: (data: CaseData) => void;
   isLoading: boolean;
+  userType: UserType;
 }
 
-const CaseInputForm = ({ onSubmit, isLoading }: CaseInputFormProps) => {
+const CaseInputForm = ({ onSubmit, isLoading, userType }: CaseInputFormProps) => {
   console.log("CaseInputForm rendering");
   
   const [formData, setFormData] = useState<Partial<CaseData>>({
@@ -43,11 +46,11 @@ const CaseInputForm = ({ onSubmit, isLoading }: CaseInputFormProps) => {
     diagnosticTests: [],
     treatmentGap: false,
     narrative: undefined,
+    plaintiffBottomLine: undefined,
+    defenseAuthority: undefined,
+    defenseRangeLow: undefined,
+    defenseRangeHigh: undefined,
   });
-
-  const handleNarrativeUpdate = (text: string) => {
-    setFormData({ ...formData, narrative: text });
-  };
 
   const handleComplete = () => {
     console.log("Form completed with data:", formData);
@@ -99,6 +102,17 @@ const CaseInputForm = ({ onSubmit, isLoading }: CaseInputFormProps) => {
       title: "Parties",
       description: "Enter the number of plaintiffs and defendants",
       component: <PartiesStep formData={formData} setFormData={setFormData} />
+    },
+    {
+      title: "Settlement Position",
+      description: "Specify bottom line or authority information",
+      component: (
+        <SettlementStrategyStep
+          formData={formData}
+          setFormData={setFormData}
+          userType={userType}
+        />
+      )
     },
     {
       title: "Case Type",

--- a/src/components/wizard-steps/SettlementStrategyStep.tsx
+++ b/src/components/wizard-steps/SettlementStrategyStep.tsx
@@ -1,0 +1,81 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { CaseData } from "@/types/verdict";
+import { UserType } from "@/types/auth";
+
+interface SettlementStrategyStepProps {
+  formData: Partial<CaseData>;
+  setFormData: (data: Partial<CaseData>) => void;
+  userType: UserType;
+}
+
+const formatNumber = (value: number | undefined): string => {
+  if (value === undefined || value === null) return "";
+  return value.toLocaleString("en-US");
+};
+
+const parseNumber = (value: string): number | undefined => {
+  if (!value) return undefined;
+  const num = Number(value.replace(/,/g, ""));
+  return isNaN(num) ? undefined : num;
+};
+
+const SettlementStrategyStep = ({ formData, setFormData, userType }: SettlementStrategyStepProps) => {
+  const handleChange = (field: keyof CaseData, value: string) => {
+    setFormData({ ...formData, [field]: parseNumber(value) });
+  };
+
+  return (
+    <div className="space-y-6">
+      {userType === 'pi_lawyer' ? (
+        <div className="space-y-2">
+          <Label htmlFor="plaintiffBottomLine">Plaintiff Bottom Line ($)</Label>
+          <Input
+            id="plaintiffBottomLine"
+            type="text"
+            value={formatNumber(formData.plaintiffBottomLine)}
+            onChange={(e) => handleChange('plaintiffBottomLine', e.target.value)}
+            placeholder="Enter minimum acceptable amount"
+          />
+        </div>
+      ) : (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="defenseAuthority">Defense Authority ($)</Label>
+            <Input
+              id="defenseAuthority"
+              type="text"
+              value={formatNumber(formData.defenseAuthority)}
+              onChange={(e) => handleChange('defenseAuthority', e.target.value)}
+              placeholder="Enter maximum authority"
+            />
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="defenseRangeLow">Target Range Low ($)</Label>
+              <Input
+                id="defenseRangeLow"
+                type="text"
+                value={formatNumber(formData.defenseRangeLow)}
+                onChange={(e) => handleChange('defenseRangeLow', e.target.value)}
+                placeholder="Low end"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="defenseRangeHigh">Target Range High ($)</Label>
+              <Input
+                id="defenseRangeHigh"
+                type="text"
+                value={formatNumber(formData.defenseRangeHigh)}
+                onChange={(e) => handleChange('defenseRangeHigh', e.target.value)}
+                placeholder="High end"
+              />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default SettlementStrategyStep;

--- a/src/lib/verdictCalculator.ts
+++ b/src/lib/verdictCalculator.ts
@@ -144,8 +144,21 @@ export const evaluateCase = (caseData: CaseData): VerdictEstimate => {
   const totalInsurance = totalPolicyLimits + umUimCoverage;
 
   // Settlement range (typically 60-80% of verdict estimates)
-  const settlementRangeLow = lowVerdict * 0.6;
-  const settlementRangeHigh = midVerdict * 0.8;
+  let settlementRangeLow = lowVerdict * 0.6;
+  let settlementRangeHigh = midVerdict * 0.8;
+
+  if (caseData.plaintiffBottomLine) {
+    settlementRangeLow = Math.max(settlementRangeLow, caseData.plaintiffBottomLine);
+  }
+  if (caseData.defenseAuthority) {
+    settlementRangeHigh = Math.min(settlementRangeHigh, caseData.defenseAuthority);
+  }
+  if (caseData.defenseRangeLow) {
+    settlementRangeLow = Math.max(settlementRangeLow, caseData.defenseRangeLow);
+  }
+  if (caseData.defenseRangeHigh) {
+    settlementRangeHigh = Math.min(settlementRangeHigh, caseData.defenseRangeHigh);
+  }
 
   // Policy exceedance calculation
   const policyExceedanceChance = totalInsurance > 0 ? 
@@ -243,6 +256,13 @@ const generateEnhancedRationale = (caseData: CaseData, estimates: any): string =
     } else {
       rationale += `appears adequate for settlement range. `;
     }
+  }
+
+  if (caseData.plaintiffBottomLine) {
+    rationale += `Plaintiff bottom line of $${caseData.plaintiffBottomLine.toLocaleString()} considered. `;
+  }
+  if (caseData.defenseAuthority) {
+    rationale += `Defense authority set at $${caseData.defenseAuthority.toLocaleString()}. `;
   }
 
   rationale += `The evaluation reflects California jury tendencies and current legal precedents.`;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -310,7 +310,11 @@ const Index = () => {
                 </CardDescription>
               </CardHeader>
               <CardContent className="max-h-[80vh] overflow-y-auto">
-                <CaseInputForm onSubmit={handleCaseSubmit} isLoading={isEvaluating} />
+                <CaseInputForm
+                  onSubmit={handleCaseSubmit}
+                  isLoading={isEvaluating}
+                  userType={userProfile.user_type}
+                />
                 {verdictEstimate && (
                   <Button 
                     onClick={handleReset} 

--- a/src/types/verdict.ts
+++ b/src/types/verdict.ts
@@ -66,6 +66,12 @@ export interface CaseData {
    * Narrative text extracted from uploaded documents
    */
   narrative?: string;
+
+  // Settlement positioning
+  plaintiffBottomLine?: number;
+  defenseAuthority?: number;
+  defenseRangeLow?: number;
+  defenseRangeHigh?: number;
 }
 
 export interface PolicyInfo {


### PR DESCRIPTION
## Summary
- add early `SettlementStrategyStep` to case wizard for bottom line/authority
- incorporate settlement strategy fields into verdict calculations and rationale
- pass user type to case form to conditionally display settlement fields
- clean up unused handler in `CaseInputForm`

## Testing
- `npm run lint`
- `npm run build`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6874c6aed864832a8214c035a9731e95